### PR TITLE
add backwards compatibility with testui 1.2.0

### DIFF
--- a/cv_pom/frameworks/testui.py
+++ b/cv_pom/frameworks/testui.py
@@ -1,4 +1,5 @@
 import base64
+import inspect
 from io import BytesIO
 from pathlib import Path
 from numpy import ndarray
@@ -29,15 +30,21 @@ class TestUICVPOMDriver(CVPOMDriver):
         self._driver = driver
 
     def _get_screenshot(self) -> ndarray:
-        image = self._driver.get_driver.get_screenshot_as_base64()
+        driver = self._driver.get_driver
+        if inspect.ismethod(self._driver.get_driver):
+            driver = self._driver.get_driver()
+        image = driver.get_screenshot_as_base64()
         sbuf = BytesIO()
         sbuf.write(base64.b64decode(str(image)))
         pimg = Image.open(sbuf)
         return cv.cvtColor(np.array(pimg), cv.COLOR_RGB2BGR)
 
     def _click_coordinates(self, x: int, y: int):
+        driver = self._driver.get_driver
+        if inspect.ismethod(self._driver.get_driver):
+            driver = self._driver.get_driver()
         self._driver.actions().w3c_actions = ActionBuilder(
-            self._driver.get_driver,
+            driver,
             mouse=PointerInput(interaction.POINTER_TOUCH, "touch"),
         )
 


### PR DESCRIPTION
version 1.2.0 

self._driver.get_driver is a property, but now in the master branch and future 1.2.1 it is a method

you can access it using two ways:

```python

self._driver.get_driver()
self._driver.driver
```